### PR TITLE
Cleanup sys.modules in CTScanTestCase

### DIFF
--- a/src/sardana/macroserver/scan/test/test_gscan.py
+++ b/src/sardana/macroserver/scan/test/test_gscan.py
@@ -40,6 +40,17 @@ from sardana.macroserver.msexception import UnknownEnv
                       "final_pos": 15})
 class CTScanTestCase(unittest.TestCase):
 
+    def setUp(self):
+        modules = []
+        for mod in sys.modules.iterkeys():
+            if "sardana" in module:
+                modules.append(mod)
+        for mod in modules:
+            try:
+                del sys.modules[mod]
+            except KeyError:
+                pass
+
     @staticmethod
     def getEnv(name):
         if name == "ActiveMntGrp":


### PR DESCRIPTION
CTScanTestCase tests fail when are executed inside the testsuite. 
It is due to  other tests import sardana modules that disabled the 
effect of @patch decorator. 

Fix it . Deleting the sardana modules from sys.modules in the setUp method.