### PR TITLE
Bytes to string for py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 
 python:
-  - "3.6"
+  - "3.5"
 
 env:
   global:
@@ -17,17 +17,16 @@ env:
 
   matrix:
   - TEST="flake8"
-  - TEST="testsuite" DOCKER_IMG=reszelaz/sardana-test
-  - TEST="testsuite" DOCKER_IMG=reszelaz/sardana-test:taurus-support-3.x
-  - TEST="doc" DOCKER_IMG=reszelaz/sardana-test
+  - TEST="testsuite" DOCKER_IMG=reszelaz/sardana-test:py3
+  - TEST="doc" DOCKER_IMG=reszelaz/sardana-test:py3
 
 
 before_install:
   # install flake8 to perform python code style check in the script part
   # install it using pip in order to get the newest version
   - if [ $TEST == "flake8" ]; then sudo apt-get update -qq ; fi
-  - if [ $TEST == "flake8" ]; then sudo apt-get install -qq python-pip; fi
-  - if [ $TEST == "flake8" ]; then sudo pip install flake8; fi
+  - if [ $TEST == "flake8" ]; then sudo apt-get install -qq python3-pip; fi
+  - if [ $TEST == "flake8" ]; then sudo pip3 install flake8; fi
 
 install:
   # run reszelaz/sardana-test docker container (Debian8 with sardana-deps)
@@ -38,7 +37,7 @@ install:
   - if [ $TEST == "testsuite" ]; then sleep 10; fi
 
   # install sardana in order to create the launcher scripts for servers
-  - if [ $TEST == "testsuite" ]; then docker exec sardana-test bash -c "cd /sardana && python setup.py install"; fi
+  - if [ $TEST == "testsuite" ]; then docker exec sardana-test bash -c "cd /sardana && python3 setup.py install"; fi
 
   # start Pool and MacroServer necessary for macro tests
   - if [ $TEST == "testsuite" ]; then docker exec sardana-test supervisorctl start Pool; fi

--- a/src/sardana/macroserver/macros/test/base.py
+++ b/src/sardana/macroserver/macros/test/base.py
@@ -195,7 +195,7 @@ class RunMacroTestCase(BaseMacroTestCase):
         self.macro_executor.registerAll()
 
     def macro_runs(self, macro_name=None, macro_params=None,
-                   wait_timeout=float("inf"), data=_NOT_PASSED):
+                   wait_timeout=None, data=_NOT_PASSED):
         """A helper method to create tests that check if the macro can be
         successfully executed for the given input parameters. It may also
         optionally perform checks on the outputs from the execution.
@@ -206,7 +206,8 @@ class RunMacroTestCase(BaseMacroTestCase):
                              If passed, they must be given as a sequence of
                              their string representations.
         :param wait_timeout: (float) maximum allowed time (in s) for the macro
-                             to finish. By default infinite timeout is used.
+                             to finish. By default infinite timeout is
+                             used (None).
         :param data: (obj) Optional. If passed, the macro data after the
                      execution is tested to be equal to this.
         """
@@ -227,14 +228,14 @@ class RunMacroTestCase(BaseMacroTestCase):
         #      in a similar way to what is done for macro data
 
     def macro_fails(self, macro_name=None, macro_params=None,
-                    wait_timeout=float("inf"), exception=None):
+                    wait_timeout=None, exception=None):
         """Check that the macro fails to run for the given input parameters
 
         :param macro_name: (str) macro name (takes precedence over macro_name
                              class member)
         :param macro_params: (seq<str>) input parameters for the macro
         :param wait_timeout: maximum allowed time for the macro to fail. By
-                             default infinite timeout is used.
+                             default infinite timeout (None) is used.
         :param exception: (str or Exception) if given, an additional check of
                         the type of the exception is done.
                         (IMPORTANT: this is just a comparison of str
@@ -274,7 +275,7 @@ class RunStopMacroTestCase(RunMacroTestCase):
         self.assertIn(state, stoppedStates, msg)
 
     def macro_stops(self, macro_name=None, macro_params=None, stop_delay=0.1,
-                    wait_timeout=float("inf")):
+                    wait_timeout=None):
         """A helper method to create tests that check if the macro can be
         successfully stoped (a.k.a. aborted) after it has been launched.
 
@@ -286,7 +287,8 @@ class RunStopMacroTestCase(RunMacroTestCase):
         :param stop_delay: (float) Time (in s) to wait between launching the
                            macro and sending the stop command. default=0.1
         :param wait_timeout: (float) maximum allowed time (in s) for the macro
-                             to finish. By default infinite timeout is used.
+                             to finish. By default infinite timeout (None) is
+                             used.
         """
         self.macro_executor.run(macro_name=macro_name or self.macro_name,
                                 macro_params=macro_params,

--- a/src/sardana/macroserver/macros/test/macroexecutor.py
+++ b/src/sardana/macroserver/macros/test/macroexecutor.py
@@ -65,7 +65,7 @@ class BaseMacroExecutor(object):
             self._common.__init__()
 
     def run(self, macro_name, macro_params=None, sync=True,
-            timeout=float("inf")):
+            timeout=None):
         """Execute macro.
 
         :param macro_name: (string) name of macro to be executed
@@ -75,7 +75,8 @@ class BaseMacroExecutor(object):
         :param sync: (bool) whether synchronous or asynchronous call
                      (default is sync=True)
         :param timeout: (float) timeout (in s) that will be passed to the wait
-                        method, in case of synchronous execution
+                        method, in case of synchronous execution; None means
+                        wait infinitely
 
             In asyncrhonous execution method :meth:`~wait` has to be explicitly
             called.
@@ -101,14 +102,15 @@ class BaseMacroExecutor(object):
         raise NotImplementedError('Method _run not implemented in class %s' %
                                   self.__class__.__name__)
 
-    def wait(self, timeout=float("inf")):
+    def wait(self, timeout=None):
         """
         Wait until macro is done. Use it in asynchronous executions.
 
-        :param timeout: (float) waiting timeout (in s)
+        :param timeout: (float) waiting timeout (in s); None means wait
+            infinitely
         """
-        if timeout <= 0:
-            timeout = float("inf")
+        if timeout is not None and timeout <= 0:
+            timeout = None
 
         self._wait(timeout)
         # TODO: workaround: this sleep is necessary to perform multiple tests.

--- a/src/sardana/macroserver/macros/test/test_macro.py
+++ b/src/sardana/macroserver/macros/test/test_macro.py
@@ -46,6 +46,6 @@ class MacroTest(BaseMacroServerTestCase, RunMacroTestCase, unittest.TestCase):
         RunMacroTestCase.setUp(self)
 
     def tearDown(self):
-        BaseMacroServerTestCase.tearDown(self)
         RunMacroTestCase.tearDown(self)
+        BaseMacroServerTestCase.tearDown(self)
         unittest.TestCase.tearDown(self)

--- a/src/sardana/macroserver/macros/test/test_scanct.py
+++ b/src/sardana/macroserver/macros/test/test_scanct.py
@@ -160,9 +160,9 @@ class ScanctTest(MeasSarTestTestCase, BaseMacroServerTestCase,
             self.assertEqual(state, desired_state, msg)
 
     def tearDown(self):
+        RunStopMacroTestCase.tearDown(self)
         BaseMacroServerTestCase.tearDown(self)
         MeasSarTestTestCase.tearDown(self)
-        RunStopMacroTestCase.tearDown(self)
 
 
 mg_config1 = {

--- a/src/sardana/macroserver/macros/test/test_scanct.py
+++ b/src/sardana/macroserver/macros/test/test_scanct.py
@@ -249,7 +249,7 @@ class AscanctTest(ScanctTest, unittest.TestCase):
         unittest.TestCase.setUp(self)
         ScanctTest.setUp(self)
 
-    def macro_runs(self, meas_config, macro_params, wait_timeout=float("inf")):
+    def macro_runs(self, meas_config, macro_params, wait_timeout=None):
         motors = [macro_params[0]]
         ScanctTest.configure_motors(self, motors)
         ScanctTest.configure_mntgrp(self, meas_config)
@@ -263,7 +263,7 @@ class AscanctTest(ScanctTest, unittest.TestCase):
         ScanctTest.check_using_output(self, expected_nb_points)
         ScanctTest.check_using_data(self, expected_nb_points)
 
-    def macro_stops(self, meas_config, macro_params, wait_timeout=float("inf"),
+    def macro_stops(self, meas_config, macro_params, wait_timeout=None,
                     stop_delay=0.1):
         motors = [macro_params[0]]
         ScanctTest.configure_motors(self, motors)
@@ -303,7 +303,7 @@ class A2scanctTest(ScanctTest, unittest.TestCase):
         unittest.TestCase.setUp(self)
         ScanctTest.setUp(self)
 
-    def macro_runs(self, meas_config, macro_params, wait_timeout=float("inf")):
+    def macro_runs(self, meas_config, macro_params, wait_timeout=None):
         motors = [macro_params[self.MOT1], macro_params[self.MOT2]]
         ScanctTest.configure_motors(self, motors)
         ScanctTest.configure_mntgrp(self, meas_config)
@@ -317,7 +317,7 @@ class A2scanctTest(ScanctTest, unittest.TestCase):
         ScanctTest.check_using_output(self, expected_nb_points)
         ScanctTest.check_using_data(self, expected_nb_points)
 
-    def macro_stops(self, meas_config, macro_params, wait_timeout=float("inf"),
+    def macro_stops(self, meas_config, macro_params, wait_timeout=None,
                     stop_delay=0.1):
         motors = [macro_params[self.MOT1], macro_params[self.MOT2]]
         ScanctTest.configure_motors(self, motors)
@@ -359,7 +359,7 @@ class MeshctTest(ScanctTest, unittest.TestCase):
         unittest.TestCase.setUp(self)
         ScanctTest.setUp(self)
 
-    def macro_runs(self, meas_config, macro_params, wait_timeout=float("inf")):
+    def macro_runs(self, meas_config, macro_params, wait_timeout=None):
         motors = [macro_params[self.MOT1], macro_params[self.MOT2]]
         ScanctTest.configure_motors(self, motors)
         ScanctTest.configure_mntgrp(self, meas_config)
@@ -373,7 +373,7 @@ class MeshctTest(ScanctTest, unittest.TestCase):
         ScanctTest.check_using_output(self, expected_nb_points)
         ScanctTest.check_using_data(self, expected_nb_points)
 
-    def macro_stops(self, meas_config, macro_params, wait_timeout=float("inf"),
+    def macro_stops(self, meas_config, macro_params, wait_timeout=None,
                     stop_delay=0.1):
         motors = [macro_params[self.MOT1], macro_params[self.MOT2]]
         ScanctTest.configure_motors(self, motors)

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1004,10 +1004,13 @@ class GScan(Logger):
             endstatus = ScanEndStatus.Normal
         except StopException:
             endstatus = ScanEndStatus.Stop
+            raise
         except AbortException:
             endstatus = ScanEndStatus.Abort
+            raise
         except Exception:
             endstatus = ScanEndStatus.Exception
+            raise
         finally:
             self._env["endstatus"] = endstatus
             self.end()
@@ -1016,8 +1019,6 @@ class GScan(Logger):
                 if hasattr(macro, 'getHooks'):
                     for hook in macro.getHooks('post-scan'):
                         hook()
-            else:
-                raise
 
     def scan_loop(self):
         raise NotImplementedError('Scan method cannot be called by '

--- a/src/sardana/tango/macroserver/test/base.py
+++ b/src/sardana/tango/macroserver/test/base.py
@@ -110,12 +110,17 @@ class BaseMacroServerTestCase(object):
                 "ds_exec_name": "MacroServer",
                 "ds_inst_name": ds_inst_name}
         ms_properties = os.path.normpath(ms_properties)
-        try:
-            os.remove(ms_properties)
-        except Exception as e:
-            msg = "Not possible to remove macroserver environment file"
-            print(msg)
-            print(("Details: %s" % e))
+        extensions = [".bak", ".dat", ".dir"]
+        for ext in extensions:
+            name = ms_properties + ext
+            if not os.path.exists(name):
+                continue
+            try:
+                os.remove(name)
+            except Exception as e:
+                msg = "Not possible to remove macroserver environment file"
+                print(msg)
+                print(("Details: %s" % e))
 
 
 if __name__ == '__main__':

--- a/src/sardana/tango/pool/MeasurementGroup.py
+++ b/src/sardana/tango/pool/MeasurementGroup.py
@@ -161,14 +161,14 @@ class MeasurementGroup(PoolGroupDevice):
         for group in synchronization:
             for param, conf in group.items():
                 group.pop(param)
-                param = SynchParam.fromStr(param)
+                param = SynchParam(int(param))
                 group[param] = conf
                 # skip repeats cause its value is just a long number
                 if param == SynchParam.Repeats:
                     continue
                 for domain, value in conf.items():
                     conf.pop(domain)
-                    domain = SynchDomain.fromStr(domain)
+                    domain = SynchDomain(int(domain))
                     conf[domain] = value
         return synchronization
 

--- a/src/sardana/tango/pool/MeasurementGroup.py
+++ b/src/sardana/tango/pool/MeasurementGroup.py
@@ -219,7 +219,7 @@ class MeasurementGroup(PoolGroupDevice):
 
     def write_Configuration(self, attr):
         data = attr.get_write_value()
-        cfg = CodecFactory().decode(('json', data), ensure_ascii=True)
+        cfg = CodecFactory().decode(('json', data))
         self.measurement_group.set_configuration_from_user(cfg)
 
     def read_NbStarts(self, attr):
@@ -251,8 +251,7 @@ class MeasurementGroup(PoolGroupDevice):
 
     def write_Synchronization(self, attr):
         data = attr.get_write_value()
-        synchronization = CodecFactory().decode(('json', data),
-                                                ensure_ascii=True)
+        synchronization = CodecFactory().decode(('json', data))
         # translate dictionary keys
         synchronization = self._synchronization_str2enum(synchronization)
         self.measurement_group.synchronization = synchronization

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -1310,7 +1310,8 @@ def ParamFactory(paramInfo):
     """
     if isinstance(paramInfo.get('type'), list):
         param = RepeatParamNode(param=paramInfo)
-        if param.min() > 0:
+        param_min = param.min()
+        if param_min is not None and param_min > 0:
             param.addRepeat()
     else:
         param = SingleParamNode(param=paramInfo)

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -734,7 +734,6 @@ class BaseDoor(MacroServerDevice):
     def write(self, msg, stream=None):
         if self.isSilent():
             return
-        msg = msg.encode('utf-8')
         self._output_stream = sys.stdout
         out = self._output_stream
         if stream is not None:

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -214,8 +214,7 @@ class ExperimentConfiguration(object):
         for mnt_grp, reply in zip(mnt_grps_names, replies):
             try:
                 mnt_grp_configs[mnt_grp] = \
-                    codec.decode(('json', reply.get_data().value),
-                                 ensure_ascii=True)[1]
+                    codec.decode(('json', reply.get_data().value))
             except Exception as e:
                 from taurus.core.util.log import warning
                 warning('Cannot load Measurement group "%s": %s',
@@ -923,7 +922,7 @@ class BaseMacroServer(MacroServerDevice):
         if evt_type not in CHANGE_EVT_TYPES:
             return ret
         try:
-            elems = CodecFactory().decode(evt_value.value, ensure_ascii=True)
+            elems = CodecFactory().decode(evt_value.value)
         except:
             self.error("Could not decode element info format=%s len=%s",
                        evt_value.value[0], len(evt_value.value[1]))

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -560,7 +560,10 @@ class BaseDoor(MacroServerDevice):
         pass
 
     def runMacro(self, obj, parameters=[], synch=False):
-        obj = obj.decode('utf-8')
+        try:
+            obj = obj.decode('utf-8')
+        except AttributeError:
+            pass
         self._user_xml = self.preRunMacro(obj, parameters)
         result = self._runMacro(self._user_xml, synch=synch)
         return self.postRunMacro(result, synch)

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -560,6 +560,7 @@ class BaseDoor(MacroServerDevice):
         pass
 
     def runMacro(self, obj, parameters=[], synch=False):
+        obj = obj.decode('utf-8')
         self._user_xml = self.preRunMacro(obj, parameters)
         result = self._runMacro(self._user_xml, synch=synch)
         return self.postRunMacro(result, synch)

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1361,7 +1361,7 @@ class MGConfiguration(object):
     def __init__(self, mg, data):
         self._mg = weakref.ref(mg)
         if isinstance(data, str):
-            data = CodecFactory().decode(('json', data), ensure_ascii=True)
+            data = CodecFactory().decode(('json', data))
         self.raw_data = data
         self.__dict__.update(data)
 
@@ -2252,7 +2252,7 @@ class Pool(TangoDevice, MoveableSource):
         elif evt_type not in CHANGE_EVT_TYPES:
             return
         try:
-            elems = CodecFactory().decode(evt_value.value, ensure_ascii=True)
+            elems = CodecFactory().decode(evt_value.value)
         except:
             self.error("Could not decode element info")
             self.info("value: '%s'", evt_value.value)

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1699,6 +1699,9 @@ class MeasurementGroup(PoolElement):
     def setConfiguration(self, configuration):
         codec = CodecFactory().getCodec('json')
         f, data = codec.encode(('', configuration))
+        # workaround until it is clarified if the JSONCodec correctly encodes
+        # to utf-8 (taurus-org/taurus#945)
+        data = data.decode("utf-8")
         self.write_attribute('configuration', data)
 
     def _setConfiguration(self, data):
@@ -1828,6 +1831,9 @@ class MeasurementGroup(PoolElement):
     def setSynchronization(self, synchronization):
         codec = CodecFactory().getCodec('json')
         _, data = codec.encode(('', synchronization))
+        # workaround until it is clarified if the JSONCodec correctly encodes
+        # to utf-8 (taurus-org/taurus#945)
+        data = data.decode("utf-8")
         self.getSynchronizationObj().write(data)
         self._last_integ_time = None
 

--- a/src/sardana/tools/config/sardana.py
+++ b/src/sardana/tools/config/sardana.py
@@ -783,8 +783,7 @@ class DevicePoolServer(TangoServer):
             pool_dp = PyTango.DeviceProxy(pool_dev_name)
 
             factory = CodecFactory()
-            elements = factory.decode(
-                pool_dp.elements, ensure_ascii='True')['new']
+            elements = factory.decode(pool_dp.elements)
 
             ctrl_classes_info = {}
             for elem in elements:


### PR DESCRIPTION
Fix bug in py3 to be able to use play a macro from
macroexecutor and sequencer. Convert from bytes to string, by
decoding.