### PR TITLE
py3: Set etree.tostring encoding

### DIFF
--- a/src/sardana/tango/macroserver/Door.py
+++ b/src/sardana/tango/macroserver/Door.py
@@ -407,7 +407,8 @@ class Door(SardanaDevice):
             return []
 
         xml_seq = self.door.run_macro(par_str_list, asynch=True)
-        return [etree.tostring(xml_seq, pretty_print=False)]
+        return [etree.tostring(xml_seq, encoding='unicode',
+                               pretty_print=False)]
 
     def is_RunMacro_allowed(self):
         return self.get_state() in [Macro.Finished, Macro.Abort,

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -566,7 +566,9 @@ class BaseDoor(MacroServerDevice):
 
     def _runMacro(self, xml, synch=False):
         if not synch:
-            return self.command_inout("RunMacro", [etree.tostring(xml)])
+            return self.command_inout("RunMacro",
+                                      [etree.tostring(xml,
+                                                      encoding='unicode')])
         timeout = self.InteractiveTimeout
         evt_wait = self._getEventWait()
         evt_wait.connect(self.getAttribute("state"))
@@ -579,7 +581,9 @@ class BaseDoor(MacroServerDevice):
             # the time stamp resolution is not better than 1 ms.
             evt_wait.clearEventSet()
             ts = time.time()
-            result = self.command_inout("RunMacro", [etree.tostring(xml)])
+            result = self.command_inout("RunMacro",
+                                        [etree.tostring(xml,
+                                                        encoding='unicode')])
             evt_wait.waitEvent(self.Running, after=ts, timeout=timeout)
             if synch:
                 evt_wait.waitEvent(self.Running, equal=False, after=ts,
@@ -1081,7 +1085,7 @@ class BaseMacroServer(MacroServerDevice):
         elif type == "MotorParam":
             pass
         elif type == "Integer":
-            int(value)
+            value = int(value)
             min = singleParamNode.min()
             max = singleParamNode.max()
             if min is not None and value < min:
@@ -1093,7 +1097,7 @@ class BaseMacroServer(MacroServerDevice):
                     "%s parameter value: %s is above maximum allowed value."
                     % (name, value))
         elif type == "Float":
-            float(value)
+            value = float(value)
             min = singleParamNode.min()
             max = singleParamNode.max()
             if min is not None and value < min:

--- a/src/sardana/taurus/core/tango/sardana/test/test_macro.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_macro.py
@@ -100,8 +100,9 @@ class MacroNodeTestCase(unittest.TestCase):
         :param macronode_xml: macronode lxml.etree
         :param expected_xml:  expected lxml.etree
         '''
-        expected_str = etree.tostring(expected_xml)
-        macronode_str = etree.tostring(macronode_xml, pretty_print=True)
+        expected_str = etree.tostring(expected_xml, encoding='unicode')
+        macronode_str = etree.tostring(macronode_xml, encoding='unicode',
+                                       pretty_print=True)
         msg = "XML encodings are not equal"
         # TODO: check why macronode_str has an extra whitespace charactger
         # at the end. strips should not be necessary

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/model.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/model.py
@@ -92,7 +92,8 @@ class MacrosListModel(Qt.QAbstractListModel):
         for macroNode in self.list:
             listElement.append(macroNode.toXml(withId=False))
         xmlTree = etree.ElementTree(listElement)
-        xmlString = etree.tostring(xmlTree, pretty_print=pretty)
+        xmlString = etree.tostring(xmlTree, encoding='unicode',
+                                   pretty_print=pretty)
         return xmlString
 
     def fromXmlString(self, xmlString):

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroparameterseditor/model.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroparameterseditor/model.py
@@ -252,4 +252,4 @@ class ParamEditorModel(Qt.QAbstractItemModel):
         """
 
         xmlElement = self.root().toXml()
-        return etree.tostring(xmlElement)
+        return etree.tostring(xmlElement, encoding='unicode')

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/model.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/model.py
@@ -239,7 +239,8 @@ class MacroSequenceTreeModel(Qt.QAbstractItemModel):
     def toXmlString(self, pretty=False, withId=True):
         xmlSequence = self.root().toXml(withId=withId)
         xmlTree = etree.ElementTree(xmlSequence)
-        xmlString = etree.tostring(xmlTree, pretty_print=pretty)
+        xmlString = etree.tostring(xmlTree, encoding='unicode',
+                                   pretty_print=pretty)
         return xmlString
 
     def fromXmlString(self, xmlString):


### PR DESCRIPTION
Sardana treats the xml as string. This behaviour changes in Py3,
since etree.tostring method returns bytes.

Set encode to `unicode` in order to fix the problems.